### PR TITLE
Test for pseudoprime number

### DIFF
--- a/prime/__init__.py
+++ b/prime/__init__.py
@@ -16,6 +16,7 @@ __author__ = "Claude Code PM System"
 from .nt import (
     is_prime_64,
     is_probable_prime,
+    is_pseudoprime,
     factorize,
     prime_run_length
 )
@@ -23,6 +24,7 @@ from .nt import (
 __all__ = [
     "is_prime_64",
     "is_probable_prime",
+    "is_pseudoprime",
     "factorize",
     "prime_run_length"
 ]

--- a/prime/nt.py
+++ b/prime/nt.py
@@ -211,6 +211,44 @@ def is_probable_prime(n: Union[int, float], k: int = 20) -> bool:
     return True
 
 
+def is_pseudoprime(n: Union[int, float], base: Union[int, float] = 2) -> bool:
+    """
+    Test if a number is a Fermat pseudoprime to a given base.
+
+    A composite number n is a pseudoprime to base a if:
+        1. n > 1 and composite
+        2. gcd(a, n) == 1
+        3. a^(n-1) ≡ 1 (mod n)
+
+    Args:
+        n: Integer to test (0 ≤ n ≤ 2^64 - 1)
+        base: Base for Fermat's little theorem check (2 ≤ base ≤ 2^64 - 1)
+
+    Returns:
+        True if n is a pseudoprime to the specified base, False otherwise.
+
+    Raises:
+        TypeError: If n or base are not integers or convertible floats.
+        ValueError: If inputs are negative, exceed 64-bit range, or base < 2.
+    """
+    n = _validate_input(n, "n")
+    base = _validate_input(base, "base")
+
+    if base < 2:
+        raise ValueError(f"base must be at least 2, got {base}")
+
+    if n < 2:
+        return False
+
+    if is_prime_64(n):
+        return False
+
+    if math.gcd(base, n) != 1:
+        return False
+
+    return pow(base, n - 1, n) == 1
+
+
 def _trial_division(n: int) -> List[int]:
     """
     Factor out small primes using trial division.

--- a/tests/test_pseudoprime.py
+++ b/tests/test_pseudoprime.py
@@ -1,0 +1,38 @@
+import pytest
+
+from prime.nt import is_pseudoprime, is_prime_64
+
+
+def test_pseudoprime_base2():
+    # 341 = 11 * 31 is a Fermat pseudoprime to base 2
+    n = 341
+    assert not is_prime_64(n)
+    assert is_pseudoprime(n, base=2)
+
+
+def test_pseudoprime_carmichael_number_multiple_bases():
+    # 561 is a Carmichael number; pseudoprime to several bases
+    n = 561
+    assert not is_prime_64(n)
+    assert is_pseudoprime(n, base=2)
+    assert is_pseudoprime(n, base=4)
+    assert is_pseudoprime(n, base=5)
+
+
+def test_pseudoprime_requires_coprime_base():
+    # base sharing factor should not count as pseudoprime
+    assert not is_pseudoprime(21, base=3)
+
+
+def test_pseudoprime_detects_prime_numbers():
+    assert not is_pseudoprime(97, base=2)
+
+
+def test_pseudoprime_float_inputs():
+    # Accept float inputs that are integer-valued
+    assert is_pseudoprime(341.0, base=2.0)
+
+
+def test_pseudoprime_invalid_base():
+    with pytest.raises(ValueError):
+        is_pseudoprime(341, base=1)


### PR DESCRIPTION
Add `is_pseudoprime` function to test if a number is a Fermat pseudoprime to a given base.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1ba869f-8dbd-445b-8626-719e9e5f136d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a1ba869f-8dbd-445b-8626-719e9e5f136d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

